### PR TITLE
Many important adaptations to wsgiservice + improvements

### DIFF
--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "v1.5"
+__version__ = "v1.5.2"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "v1.4.3"
+__version__ = "v1.5"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "v1.5.2"
+__version__ = "1.5.3"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.7"
+__version__ = "1.6"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.6"
+__version__ = "1.5.7"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jsonschema
 six>=1.3.0
 aniso8601>=0.82
 https://github.com/beekpr/wsgiservice/archive/0.4.5.zip#egg=wsgiservice-0.4.5
+PasteDeploy==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
 ]
 
 dependency_links=[
-        "https://github.com/beekpr/wsgiservice/archive/0.4.5.zip#egg=wsgiservice-0.4.5"
+    "https://github.com/beekpr/wsgiservice/archive/0.4.5.zip#egg=wsgiservice-0.4.5"
 ]
 
 tests_require = ['nose', 'rednose', 'blinker', 'tzlocal']

--- a/wsgiservice_restplus/api.py
+++ b/wsgiservice_restplus/api.py
@@ -122,11 +122,6 @@ class Api(object):
         for name, definition in ns.models.items():
             self.models[name] = definition
 
-        # TODO: FUL-3505
-        # # Register error handlers
-        # for exception, handler in ns.error_handlers.items():
-        #     self.error_handlers[exception] = handler
-
 
     def _security_requirements_in_authorizations(self, ns):
 
@@ -138,7 +133,6 @@ class Api(object):
                         if security_requirement not in self.authorizations:
                             return False
         return True
-
 
     def get_resources(self):
         """Returns resources held by this instance, then creates and add SwaggerResourceClass as well

--- a/wsgiservice_restplus/converters.py
+++ b/wsgiservice_restplus/converters.py
@@ -3,3 +3,8 @@ from paste.deploy.converters import asbool
 def Boolean(value):
     """Converts value to Boolean"""
     return asbool(value)
+
+
+def String(value):
+    """Converts value to a string"""
+    return value

--- a/wsgiservice_restplus/converters.py
+++ b/wsgiservice_restplus/converters.py
@@ -1,0 +1,5 @@
+from paste.deploy.converters import asbool
+
+def Boolean(value):
+    """Converts value to Boolean"""
+    return asbool(value)

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -92,8 +92,8 @@ class Raw(object):
         than the publicly named value.
     :param str title: The field title (for documentation purpose)
     :param str description: The field description (for documentation purpose)
-    :param bool required: Is the field required ?
-    :param bool readonly: Is the field read only ? (for documentation purpose)
+    :param bool required: Is the field mandatory?
+    :param bool readonly: Is the field read only? (for documentation purpose)
     :param example: An optional data example (for documentation purpose)
     :param callable mask: An optional mask function to be applied to output
     '''
@@ -105,15 +105,22 @@ class Raw(object):
     __schema_example__ = None
 
     def __init__(self, default=None, attribute=None, title=None, description=None,
-                 required=None, readonly=None, example=None, mask=None, **kwargs):
+                 mandatory=None, readonly=None, example=None, mask=None, **kwargs):
         self.attribute = attribute
         self.default = default
         self.title = title
         self.description = description
-        self.required = required
+        self.required = mandatory
         self.readonly = readonly
         self.example = example or self.__schema_example__
         self.mask = mask
+
+        self.valid_params = {
+            "re": kwargs.get('re', None),
+            "convert": kwargs.get('convert', None),
+            "doc": self.description or None,
+            "mandatory": kwargs.get('mandatory', False)
+        }
 
     def format(self, value):
         '''
@@ -188,8 +195,6 @@ class Nested(Raw):
             schema['items'] = {'$ref': ref}
         else:
             schema['$ref'] = ref
-            # if not self.allow_null and not self.readonly:
-            #     schema['required'] = True
 
         return schema
 
@@ -574,10 +579,10 @@ class Polymorph(Nested):
 
     :param dict mapping: Maps classes to their model/fields representation
     '''
-    def __init__(self, mapping, required=False, **kwargs):
+    def __init__(self, mapping, mandatory=False, **kwargs):
         self.mapping = mapping
         parent = self.resolve_ancestor(list(itervalues(mapping)))
-        super(Polymorph, self).__init__(parent, allow_null=not required, **kwargs)
+        super(Polymorph, self).__init__(parent, allow_null=not mandatory, **kwargs)
 
 
     def resolve_ancestor(self, models):

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -78,6 +78,16 @@ def to_marshallable_type(obj):
     return dict(obj.__dict__)
 
 
+def make_mandatory(field_obj):
+    """Makes the field object mandatory"""
+
+    if hasattr(field_obj, 'valid_params'):
+        field_obj.valid_params['mandatory'] = True
+        return field_obj
+    else:
+        return field_obj
+
+
 class Raw(object):
     '''
     Raw provides a base field class from which others should extend. It
@@ -207,6 +217,7 @@ class Nested(Raw):
 
 
 class List(Raw):
+
     '''
     Field for marshalling lists of other fields.
 
@@ -214,6 +225,7 @@ class List(Raw):
 
     :param cls_or_instance: The field type the list will contain.
     '''
+
     def __init__(self, cls_or_instance, **kwargs):
         self.min_items = kwargs.pop('min_items', None)
         self.max_items = kwargs.pop('max_items', None)
@@ -228,6 +240,10 @@ class List(Raw):
             if not isinstance(cls_or_instance, Raw):
                 raise MarshallingError(error_msg)
             self.container = cls_or_instance
+
+    def __iter__(self):
+
+        return self.model
 
     def format(self, value):
         # Convert all instances in typed list to container type

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -79,7 +79,7 @@ def to_marshallable_type(obj):
 
 
 def make_mandatory(field_obj):
-    """Makes the field object mandatory"""
+    """Makes the field object mandatory - WIP """
 
     if hasattr(field_obj, 'valid_params'):
         field_obj.valid_params['mandatory'] = True

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -447,15 +447,18 @@ class Boolean(Raw):
 
 
 class DateTime(MinMaxMixin, Raw):
-    '''
-    Return a formatted datetime string in UTC. Supported formats are RFC 822 and ISO 8601.
+    """
+    Return a formatted datetime string in UTC.
 
     See :func:`email.utils.formatdate` for more info on the RFC 822 format.
 
     See :meth:`datetime.datetime.isoformat` for more info on the ISO 8601 format.
 
     :param str dt_format: ``rfc822`` or ``iso8601``
-    '''
+    :keyword add_format: Additional time format string note to be added to the
+    field.description, eg. "(UTC timezone, `yyyy-mm-ddTHH:MM:SS` format)".
+    :type add_format: str
+    """
     __schema_type__ = 'string'
     __schema_format__ = 'date-time'
 
@@ -464,6 +467,10 @@ class DateTime(MinMaxMixin, Raw):
         self.dt_format = dt_format
         if not self.valid_params.get('convert'):
             self.valid_params['convert'] = str
+
+        format_description = kwargs.get('add_format')
+        if format_description and type(format_description) == str:
+            self.description += format_description
 
     def parse(self, value):
         if value is None:

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -388,7 +388,7 @@ class Float(NumberMixin, Raw):
     '''
 
     def __init__(self, *args, **kwargs):
-        super(Integer, self).__init__(*args, **kwargs)
+        super(Float, self).__init__(*args, **kwargs)
         if not self.valid_params.get('convert'):
             self.valid_params['convert'] = float
 

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -11,6 +11,7 @@ from six import itervalues, text_type, string_types
 from wsgiservice_restplus.errors import RestError
 from wsgiservice_restplus.inputs import date_from_iso8601, datetime_from_iso8601, datetime_from_rfc822
 from wsgiservice_restplus.utils import not_none
+from wsgiservice_restplus.converters import Boolean as BooleanConverter
 
 
 __all__ = ('Raw', 'String', 'FormattedString',
@@ -439,7 +440,7 @@ class Boolean(Raw):
     def __init__(self, *args, **kwargs):
         super(Boolean, self).__init__(*args, **kwargs)
         if not self.valid_params.get('convert'):
-            self.valid_params['convert'] = bool
+            self.valid_params['convert'] = BooleanConverter
 
     def format(self, value):
         return bool(value)

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -231,6 +231,8 @@ class List(Raw):
         self.max_items = kwargs.pop('max_items', None)
         self.unique = kwargs.pop('unique', None)
         super(List, self).__init__(**kwargs)
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = list
         error_msg = 'The type of the list elements must be a subclass of fields.Raw'
         if isinstance(cls_or_instance, type):
             if not issubclass(cls_or_instance, Raw):
@@ -286,6 +288,8 @@ class StringMixin(object):
         self.max_length = kwargs.pop('max_length', None)
         self.pattern = kwargs.pop('pattern', None)
         super(StringMixin, self).__init__(*args, **kwargs)
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = str
 
     def schema(self):
         schema = super(StringMixin, self).schema()
@@ -336,6 +340,8 @@ class String(StringMixin, Raw):
         self.discriminator = kwargs.pop('discriminator', None)
         super(String, self).__init__(*args, **kwargs)
         self.required = self.discriminator or self.required
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = str
 
     def format(self, value):
         try:
@@ -360,6 +366,11 @@ class Integer(NumberMixin, Raw):
     '''
     __schema_type__ = 'integer'
 
+    def __init__(self, *args, **kwargs):
+        super(Integer, self).__init__(*args, **kwargs)
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = int
+
     def format(self, value):
         try:
             if value is None:
@@ -375,6 +386,11 @@ class Float(NumberMixin, Raw):
 
     ex : 3.141592653589793 3.1415926535897933e-06 3.141592653589793e+24 nan inf -inf
     '''
+
+    def __init__(self, *args, **kwargs):
+        super(Integer, self).__init__(*args, **kwargs)
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = float
 
     def format(self, value):
         try:
@@ -420,6 +436,11 @@ class Boolean(Raw):
     '''
     __schema_type__ = 'boolean'
 
+    def __init__(self, *args, **kwargs):
+        super(Boolean, self).__init__(*args, **kwargs)
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = bool
+
     def format(self, value):
         return bool(value)
 
@@ -440,6 +461,8 @@ class DateTime(MinMaxMixin, Raw):
     def __init__(self, dt_format='iso8601', **kwargs):
         super(DateTime, self).__init__(**kwargs)
         self.dt_format = dt_format
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = str
 
     def parse(self, value):
         if value is None:
@@ -509,6 +532,8 @@ class Date(DateTime):
     def __init__(self, **kwargs):
         kwargs.pop('dt_format', None)
         super(Date, self).__init__(dt_format='iso8601', **kwargs)
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = str
 
     def parse(self, value):
         if value is None:
@@ -538,6 +563,9 @@ class Url(StringMixin, Raw):
         self.endpoint = endpoint
         self.absolute = absolute
         self.scheme = scheme
+
+        if not self.valid_params.get('convert'):
+            self.valid_params['convert'] = str
 
 
 class FormattedString(StringMixin, Raw):

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -12,6 +12,7 @@ from wsgiservice_restplus.errors import RestError
 from wsgiservice_restplus.inputs import date_from_iso8601, datetime_from_iso8601, datetime_from_rfc822
 from wsgiservice_restplus.utils import not_none
 from wsgiservice_restplus.converters import Boolean as BooleanConverter
+from wsgiservice_restplus.converters import String as StringConverter
 
 
 __all__ = ('Raw', 'String', 'FormattedString',
@@ -346,7 +347,7 @@ class String(StringMixin, Raw):
         super(String, self).__init__(*args, **kwargs)
         self.required = self.discriminator or self.required
         if not self.valid_params.get('convert'):
-            self.valid_params['convert'] = str
+            self.valid_params['convert'] = StringConverter
 
     def format(self, value):
         try:

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -133,6 +133,10 @@ class Raw(object):
             "mandatory": kwargs.get('mandatory', False)
         }
 
+        format_description = kwargs.get('add_format')
+        if format_description and type(format_description) == str:
+            self.description += ' ' + format_description
+
     def format(self, value):
         '''
         Formats a field's value. No-op by default - field classes that
@@ -467,10 +471,6 @@ class DateTime(MinMaxMixin, Raw):
         self.dt_format = dt_format
         if not self.valid_params.get('convert'):
             self.valid_params['convert'] = str
-
-        format_description = kwargs.get('add_format')
-        if format_description and type(format_description) == str:
-            self.description += format_description
 
     def parse(self, value):
         if value is None:

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -174,7 +174,7 @@ class Namespace(object):
         model = Model.inherit(name, *specs)
         return self.add_model(name, model)
 
-    def expect(self, *inputs, **kwargs):    #todo: to be deprecated!
+    def expect(self, *inputs, **kwargs):
         """
         A decorator to Specify the expected input model
 
@@ -222,9 +222,7 @@ class Namespace(object):
 
         return wrapper
 
-
     def _prepare_validation_dict(self, model):
-
         """Generates the content of the _validations dictionary (normally used by validate decorator \
         from wsgiservice.decorators) from a single Model object.
 
@@ -235,7 +233,7 @@ class Namespace(object):
 
         validations = {}
 
-        for field_name, field in model.items():
+        for field_name, field in model.iteritems():
             validations[field_name] = {
                 're': field.valid_params.get('re', None),
                 'convert': field.valid_params.get('convert', None),
@@ -339,10 +337,8 @@ class Namespace(object):
                 documented._validations = {}
             documented._validations[name] = {'re': re, 'convert': convert, 'doc': doc, 'mandatory': mandatory}
 
-            # ---- doc ---:
             self._handle_api_doc(documented, api_params)
             return documented
-            # ------------
 
         return wrapper
 

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -192,14 +192,49 @@ class Namespace(object):
         return self.doc(**params)
 
 
-    def query_model(self, model):  #todo: W.I.P - finish writing
+    def payload_model(self, *models, **kwargs):  #todo: W.I.P - finish writing
         """A decorator that adds model data to swagger api documentation as well as
         applies wsgiservice validation using the model object provided.
 
         :param model:
         :return:
         """
-        pass
+
+        expect = []
+        params = {
+            'validate': self._validate,
+            'expect': expect
+        }
+        for model in models:
+            expect.append(model)
+
+            # run validate on each payload param:
+            validate_params = {}
+            validate_params['required'] = model[]
+            validate_params['in'] = model[]
+
+
+
+        def wrapper(documented):
+
+            self._handle_api_doc(documented, api_params)
+            return documented
+
+        return wrapper
+
+
+    def validate_model_parameter(self, cls, model):
+
+        """Adds _validate attribute to a method/class for each field element in a Model
+
+        :param model:
+        :return:
+        """
+
+        if not hasattr(documented, '_validations'):
+            documented._validations = {}
+        documented._validations[name] = {'re': re, 'convert': convert, 'doc': doc, 'mandatory': mandatory}
+
 
 
     def as_list(self, field):
@@ -295,8 +330,10 @@ class Namespace(object):
                 documented._validations = {}
             documented._validations[name] = {'re': re, 'convert': convert, 'doc': doc, 'mandatory': mandatory}
 
+            # ---- doc ---:
             self._handle_api_doc(documented, api_params)
             return documented
+            # ------------
 
         return wrapper
 

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -192,6 +192,16 @@ class Namespace(object):
         return self.doc(**params)
 
 
+    def query_model(self, model):  #todo: W.I.P - finish writing
+        """A decorator that adds model data to swagger api documentation as well as
+        applies wsgiservice validation using the model object provided.
+
+        :param model:
+        :return:
+        """
+        pass
+
+
     def as_list(self, field):
         """Allow to specify nested lists for documentation"""
         field.__apidoc__ = merge(getattr(field, '__apidoc__', {}), {'as_list': True})

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -193,7 +193,7 @@ class Namespace(object):
 
 
     def payload_model(self, *models, **kwargs):  #todo: W.I.P - finish writing
-        """A decorator that adds model data to swagger api documentation as well as
+        """A decorator that adds payload parameters model data to swagger api documentation as well as
         applies wsgiservice validation using the model object provided.
 
         :param model:
@@ -205,17 +205,39 @@ class Namespace(object):
             'validate': self._validate,
             'expect': expect
         }
+
         for model in models:
             expect.append(model)
 
-            # run validate on each payload param:
-            validate_params = {}
-            validate_params['required'] = model[]
-            validate_params['in'] = model[]
+            validations = {}
+            api_params = {}
 
+            for field_name, field in model.items():
 
+                doc = field.valid_params.get('doc', None)
+                mandatory = field.valid_params.get('mandatory', False)
+
+                # run validate on each payload param:
+                param = {
+                    'required': mandatory,
+                    'description': doc,
+                    'in': 'body',
+                }
+                api_params = {'expect': {field_name: param}}
+
+                # Add each param to validations:
+                validations[field_name] = {
+                    're': field.valid_params.get('re', None),
+                    'convert': field.valid_params.get('convert', None),
+                    'doc': doc,
+                    'mandatory': mandatory,
+                }
 
         def wrapper(documented):
+
+            if not hasattr(documented, '_validations'):
+                documented._validations = {}
+            documented._validations = validations
 
             self._handle_api_doc(documented, api_params)
             return documented
@@ -231,11 +253,28 @@ class Namespace(object):
         :return:
         """
 
-        if not hasattr(documented, '_validations'):
-            documented._validations = {}
-        documented._validations[name] = {'re': re, 'convert': convert, 'doc': doc, 'mandatory': mandatory}
+        validations = {}
+        api_params = {}
 
+        for field_name, field in model.items():
+            doc = field.valid_params.get('doc', None)
+            mandatory = field.valid_params.get('mandatory', False)
 
+            # run validate on each payload param:
+            param = {
+                'required': mandatory,
+                'description': doc,
+                'in': 'body',
+            }
+            api_params = {'params': {field_name: param}}
+
+            # Add each param to validations:
+            validations[field_name] = {
+                're': field.valid_params.get('re', None),
+                'convert': field.valid_params.get('convert', None),
+                'doc': doc,
+                'mandatory': mandatory,
+            }
 
     def as_list(self, field):
         """Allow to specify nested lists for documentation"""

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -243,7 +243,6 @@ class Namespace(object):
 
         return validations
 
-
     def as_list(self, field):
         """Allow to specify nested lists for documentation"""
         field.__apidoc__ = merge(getattr(field, '__apidoc__', {}), {'as_list': True})
@@ -320,7 +319,7 @@ class Namespace(object):
                     final data type. Ideal candidates for this are the
                     built-ins int or float functions. If the function raises a
                     ValueError, this is reported to the client as a 400 error.
-        :type convert: callable
+        :type convert: callable or type (eg. int, str, bool, etc.)
         :param mandatory: Whether the parameter is mandatory. By default this is `True`.
         :type mandatory: bool
         """
@@ -329,6 +328,12 @@ class Namespace(object):
         param['required'] = mandatory
         param['in'] = _in
         param['description'] = doc or None
+
+        if type(convert) == type:
+            param['type'] = convert
+        elif hasattr(convert, "converts_to_type"):
+            param['type'] = eval(convert.converts_to_type)
+
         api_params = {'params': {name: param}}
 
         def wrapper(documented):


### PR DESCRIPTION
At the moment the `@validate` decorator used on a payload variable will be substituted with the `ns.payload_param` decorator, however, for some endpoints with a large no. parameters expected in a request body will require using a lot of those decorators. Instead, a better idea would be to define all payload parameters in a single model (stored separately) and include them with one (expect) decorator. Currently, however, the `ns.expect` decorator does not include the `@validate` decorator functionality  from wsgiservice - so that needs to be added.

Added `Boolean` and `String` converters to the library (required by Beekeeper version of `wsgiservice`) - this should fix issues with comment and post text posting (issue FUL-4485)
