### PR TITLE
FUL-5009: Ability to restrict resources for internal use only

### DIFF
--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/examples/general/simple2.py
+++ b/examples/general/simple2.py
@@ -1,0 +1,156 @@
+import logging
+import sys
+
+from wsgiservice import Resource, raise_404, raise_403, raise_201, raise_409, raise_200, validate
+
+from wsgiservice_restplus import namespace, fields
+from wsgiservice_restplus.api import Api
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+
+api = Api(
+    version='1',
+    contact_url=None,
+    contact_email=None,
+    doc=False,
+    tags=None,
+    prefix='/',
+    default_mediatype='application/json',
+    catch_all_404s=False,
+    serve_challenge_on_401=False,
+)
+
+ping_ns = namespace.Namespace(
+    name="Ping Pong Endpoint",
+    description="Test endpoint for trying out the request calls and swagger documentation",
+    internal=False
+)
+
+api.add_namespace(ping_ns)
+
+def Integer(value):
+    """Converts value to Integer"""
+    return int(value)
+
+
+
+# ===== MODELS: ======
+
+tesball_payload = ping_ns.model(
+    "Testball Payload",
+    {
+        "good": fields.Boolean(
+            description="Flag indicating that the ball was served very well.",
+            example=True
+        )
+    }
+)
+
+
+pong_model = ping_ns.model(
+    "Pong Response",
+    {
+        "good": fields.String(
+            description="Some snappy response from receiving a ping request",
+            example="Wow, that was a nice shot!"),
+
+        "bad": fields.String(
+            description="Some BAD response from receiving a ping request",
+            example="Wow, that was a BAAAAAAD shot!")
+    }
+)
+
+
+ball_model = ping_ns.model(
+    "ball model",
+    {
+        "ball": fields.Boolean(
+            description="True means a ball was decent, False means the ball was weak!"
+        )
+    }
+)
+
+ball_count_model = ping_ns.model(
+    "ball count model",
+    {
+        "rally": fields.Integer(
+            description="Number of a rally (URL variable)"
+        ),
+        "balls": fields.Integer(
+            description="Number of balls exchanged in a rally (received in a request query)"
+        )
+    }
+)
+
+# ===== ENDPOINTS ======
+
+
+@ping_ns.route('/testball', internal=True)
+class Testball(Resource):
+    """Example endpoint function for TESTING purposes only!"""
+
+    def GET(self):
+        return "This is a test ball endpoint - please make a POST request with good or bad " \
+               "(strings)"
+
+    @ping_ns.payload_model(tesball_payload)
+    @ping_ns.marshal_with(pong_model)
+    def POST(self, good=False, bad=True):
+        """Returns a ball response comment.
+        Praises if ball=True or mocks if ball=False (or else)"""
+
+        logging.info("BALL WAS good:{} bad: {}".format(good, bad))
+
+        if good:
+            return {"response": "Wow, that was a nice shot!"}
+        else:
+            return {"response": "Dread lord, you're calling this a serve? ;p"}
+
+
+@ping_ns.route('/ping')
+class Ping(Resource):
+    """Example endpoint function for TESTING purposes only!"""
+
+    def GET(self):
+        """Returns a simple ping-pong dictionary"""
+        return {"what?": 'did you just ping me?'}
+
+    @ping_ns.expect(ball_model)
+    @ping_ns.payload_param(name='ball', doc='Switch to make the ball good (True) or bad (False)', mandatory=False)
+    @ping_ns.marshal_with(pong_model)
+    def POST(self, ball):
+        """Returns a ball response comment.
+        Praises if ball=True or mocks if ball=False (or else)"""
+
+        logging.info("BALL WAS {}".format(ball))
+
+        if ball is True:
+            return {"response": "Wow, that was a nice shot!"}
+        else:
+            return {"response": "Dread lord, you're calling this a serve? ;p"}
+
+
+@ping_ns.path_param(name='rally', description='RALLY NUMBER (hybrid)', convert=Integer)
+@ping_ns.route('/ping/{rally}')
+class Pong(Resource):
+
+    @ping_ns.query_param(name='balls', doc='NUMBER OF BALLS EXCHANGED (HYBRYD!)')
+    @ping_ns.marshal_with(ball_count_model)
+    def GET(self, rally, balls=1):
+        """Returns a number of balls in a given rally"""
+
+        return {"nr of balls exchanged": balls, "rally": rally}
+
+
+test_swagger = api.__schema__()
+
+print test_swagger
+
+if __name__ == "__main__":
+
+    app = api.create_wsgiservice_app()
+
+    from wsgiref.simple_server import make_server
+    print "Running on port 8002"
+
+    make_server('', 8002, app).serve_forever()

--- a/examples/general/simple2.py
+++ b/examples/general/simple2.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from wsgiservice import Resource, raise_404, raise_403, raise_201, raise_409, raise_200, validate
+from wsgiservice.resource import Resource
 
 from wsgiservice_restplus import namespace, fields
 from wsgiservice_restplus.api import Api
@@ -23,7 +23,6 @@ api = Api(
 ping_ns = namespace.Namespace(
     name="Ping Pong Endpoint",
     description="Test endpoint for trying out the request calls and swagger documentation",
-    internal=False
 )
 
 api.add_namespace(ping_ns)
@@ -31,7 +30,6 @@ api.add_namespace(ping_ns)
 def Integer(value):
     """Converts value to Integer"""
     return int(value)
-
 
 
 # ===== MODELS: ======
@@ -46,7 +44,6 @@ tesball_payload = ping_ns.model(
     }
 )
 
-
 pong_model = ping_ns.model(
     "Pong Response",
     {
@@ -59,7 +56,6 @@ pong_model = ping_ns.model(
             example="Wow, that was a BAAAAAAD shot!")
     }
 )
-
 
 ball_model = ping_ns.model(
     "ball model",
@@ -85,7 +81,7 @@ ball_count_model = ping_ns.model(
 # ===== ENDPOINTS ======
 
 
-@ping_ns.route('/testball', internal=True)
+@ping_ns.route('/testball', public=True)
 class Testball(Resource):
     """Example endpoint function for TESTING purposes only!"""
 
@@ -107,7 +103,7 @@ class Testball(Resource):
             return {"response": "Dread lord, you're calling this a serve? ;p"}
 
 
-@ping_ns.route('/ping')
+@ping_ns.route('/ping', public=False)
 class Ping(Resource):
     """Example endpoint function for TESTING purposes only!"""
 

--- a/examples/general/simple2.py
+++ b/examples/general/simple2.py
@@ -23,6 +23,7 @@ api = Api(
 ping_ns = namespace.Namespace(
     name="Ping Pong Endpoint",
     description="Test endpoint for trying out the request calls and swagger documentation",
+    public=True
 )
 
 api.add_namespace(ping_ns)
@@ -81,7 +82,7 @@ ball_count_model = ping_ns.model(
 # ===== ENDPOINTS ======
 
 
-@ping_ns.route('/testball', public=True)
+@ping_ns.route('/testball', public=False)
 class Testball(Resource):
     """Example endpoint function for TESTING purposes only!"""
 
@@ -103,7 +104,7 @@ class Testball(Resource):
             return {"response": "Dread lord, you're calling this a serve? ;p"}
 
 
-@ping_ns.route('/ping', public=False)
+@ping_ns.route('/ping', public=True)
 class Ping(Resource):
     """Example endpoint function for TESTING purposes only!"""
 
@@ -126,8 +127,8 @@ class Ping(Resource):
             return {"response": "Dread lord, you're calling this a serve? ;p"}
 
 
+@ping_ns.route('/ping/{rally}', public=True)
 @ping_ns.path_param(name='rally', description='RALLY NUMBER (hybrid)', convert=Integer)
-@ping_ns.route('/ping/{rally}')
 class Pong(Resource):
 
     @ping_ns.query_param(name='balls', doc='NUMBER OF BALLS EXCHANGED (HYBRYD!)')

--- a/wsgiservice_restplus/api.py
+++ b/wsgiservice_restplus/api.py
@@ -19,8 +19,7 @@ HEADERS_BLACKLIST = ('Content-Length',)
 # Replaced output_json by None (cf. wsgiservice.Resource content negotiation)
 DEFAULT_REPRESENTATIONS = [('application/json', None)]
 
-from wsgiservice import Resource as WSGIResource
-from re import match
+from wsgiservice.resource import Resource as WSGIResource
 
 
 class Api(object):

--- a/wsgiservice_restplus/api.py
+++ b/wsgiservice_restplus/api.py
@@ -218,12 +218,7 @@ def generate_swagger_resource(api, swagger_path):
 
         def GET(self, internal=False):
 
-            show_internal = False
-            try:
-                if match('[T,t][r,R][u,U][e,E]', internal[:4]):
-                    show_internal = True
-            except Exception:
-                pass
+            show_internal = (unicode(internal) or "").lower() == "true"
 
             self.type = str('application/json')
             return api.__schema__(show_internal=show_internal)

--- a/wsgiservice_restplus/api.py
+++ b/wsgiservice_restplus/api.py
@@ -86,6 +86,7 @@ class Api(object):
         self._default_error_handler = None
         self.tags = tags or []
         self._schema = None # cache for Swagger JSON specification
+        self._internal_schema = None
         self.models = {}
         self._refresolver = None
         self.format_checker = format_checker
@@ -186,8 +187,14 @@ class Api(object):
         :returns dict: the schema as a serializable dict
         """
 
-        if not self._schema or show_internal:
-            self._schema = Swagger(self).as_dict(show_internal=show_internal)
+        if show_internal and self._internal_schema:
+            return self._internal_schema
+        elif show_internal:
+            self._internal_schema = Swagger(self).as_dict(show_internal=show_internal)
+            return self._internal_schema
+
+        if not self._schema:
+            self._schema = Swagger(self).as_dict()
 
         return self._schema
 

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -36,7 +36,7 @@ class Namespace(object):
         self.decorators = decorators if decorators else []
         self.resources = []
         self.apis = []
-        self.public = kwargs.get('public', True)
+        self.public = kwargs.get('public', False)
 
         if 'api' in kwargs:
             self.apis.append(kwargs['api'])
@@ -58,7 +58,7 @@ class Namespace(object):
             namespace.add_resource(Foo, '/foo', endpoint="foo")
             namespace.add_resource(FooSpecial, '/special/foo', endpoint="foo")
         """
-        resource.public = kwargs.get('public', True)
+        resource.public = kwargs.get('public', False)
 
         self.resources.append((resource, url, kwargs))
         for api in self.apis:

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -34,6 +34,7 @@ class Namespace(object):
         self.decorators = decorators if decorators else []
         self.resources = []
         self.apis = []
+        self.internal = kwargs.get('internal', False)
 
         if 'api' in kwargs:
             self.apis.append(kwargs['api'])
@@ -80,6 +81,8 @@ class Namespace(object):
             else:
                 if cls._path != url:
                     raise ValueError
+
+            cls.internal = kwargs.get('internal', False)
 
             self.add_resource(cls, url, **kwargs)
             return cls

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -22,6 +22,8 @@ class Namespace(object):
     :param list decorators: A list of decorators to apply to each resources
     :param bool validate: Whether or not to perform validation on this namespace
     :param Api api: an optional API to attache to the namespace
+    :param bool public: Flags the namespace as public (when public=False, Api will hide this
+    resource from swagger.json unless its retrieved via interna=true query parameter.)
     """
 
     def __init__(self, name, description=None, path='/', decorators=None, validate=None, **kwargs):
@@ -34,7 +36,7 @@ class Namespace(object):
         self.decorators = decorators if decorators else []
         self.resources = []
         self.apis = []
-        self.internal = kwargs.get('internal', False)
+        self.public = kwargs.get('public', True)
 
         if 'api' in kwargs:
             self.apis.append(kwargs['api'])
@@ -56,6 +58,8 @@ class Namespace(object):
             namespace.add_resource(Foo, '/foo', endpoint="foo")
             namespace.add_resource(FooSpecial, '/special/foo', endpoint="foo")
         """
+        resource.public = kwargs.get('public', True)
+
         self.resources.append((resource, url, kwargs))
         for api in self.apis:
             api.register_resource(self, resource, url, **kwargs)
@@ -81,8 +85,6 @@ class Namespace(object):
             else:
                 if cls._path != url:
                     raise ValueError
-
-            cls.internal = kwargs.get('internal', False)
 
             self.add_resource(cls, url, **kwargs)
             return cls

--- a/wsgiservice_restplus/swagger.py
+++ b/wsgiservice_restplus/swagger.py
@@ -158,10 +158,12 @@ class Swagger(object):
         responses = self.register_errors()
 
         for ns in self.api.namespaces:
-            if not show_internal and ns.internal:
+            if ns.internal and not show_internal:
                 continue
             for resource, url, kwargs in ns.resources:
-                if show_internal or not resource.internal:
+                if resource.internal and not show_internal:
+                    continue
+                else:
                     paths[extract_path(url)] = self.serialize_resource(ns, resource, url, kwargs)
 
         specs = {
@@ -176,7 +178,7 @@ class Swagger(object):
             'tags': tags,
             'definitions': self.serialize_definitions() or None,
             'responses': responses or None,
-            'host': None,       #NOTE: removed get_host() as not used.
+            'host': None,
         }
         return not_none(specs)
 

--- a/wsgiservice_restplus/swagger.py
+++ b/wsgiservice_restplus/swagger.py
@@ -158,10 +158,10 @@ class Swagger(object):
         responses = self.register_errors()
 
         for ns in self.api.namespaces:
-            if ns.internal and not show_internal:
+            if not ns.public and not show_internal:
                 continue
             for resource, url, kwargs in ns.resources:
-                if resource.internal and not show_internal:
+                if not resource.public and not show_internal:
                     continue
                 else:
                     paths[extract_path(url)] = self.serialize_resource(ns, resource, url, kwargs)


### PR DESCRIPTION
Namespaces or `route()` method can now be given `internal=True` parameter to restrict the namespace/resource respectively for internal display only. Thus:

`/api/2/swagger.json` will return a swagger.json which will NOT include resources/namespaces that have been marked as internal.

`/api/2/swagger.json?internal=true` will return the entire swagger.json (including internal endpoints)


