### PR TITLE
FUL-5527: Namespaces shouldn't toggle resources public/internal

### DIFF
--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/examples/general/simple2.py
+++ b/examples/general/simple2.py
@@ -23,7 +23,6 @@ api = Api(
 ping_ns = namespace.Namespace(
     name="Ping Pong Endpoint",
     description="Test endpoint for trying out the request calls and swagger documentation",
-    public=True
 )
 
 api.add_namespace(ping_ns)
@@ -82,7 +81,7 @@ ball_count_model = ping_ns.model(
 # ===== ENDPOINTS ======
 
 
-@ping_ns.route('/testball', public=False)
+@ping_ns.route('/testball')
 class Testball(Resource):
     """Example endpoint function for TESTING purposes only!"""
 

--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -36,7 +36,6 @@ class Namespace(object):
         self.decorators = decorators if decorators else []
         self.resources = []
         self.apis = []
-        self.public = kwargs.get('public', False)
 
         if 'api' in kwargs:
             self.apis.append(kwargs['api'])

--- a/wsgiservice_restplus/swagger.py
+++ b/wsgiservice_restplus/swagger.py
@@ -158,8 +158,6 @@ class Swagger(object):
         responses = self.register_errors()
 
         for ns in self.api.namespaces:
-            if not ns.public and not show_internal:
-                continue
             for resource, url, kwargs in ns.resources:
                 if not resource.public and not show_internal:
                     continue


### PR DESCRIPTION
Namespaces can be used to switch all its resources off (by supplying `public=False`), but they cannot be used to make all of them public via `public=True`, this needs to be done on individual basis - in each resource class. Thus it'd make sense to remove the public=T/F switch from namespaces, leaving this to resources only.

Please note, that this pull request will require some minor changes in the beekeeper codebase too ( just remove the public flags from namespaces, resources are `public=False` by default already) 