### PR TITLE
FUL-11652: Allow entity endpoint versioning documentation

### DIFF
--- a/wsgiservice_restplus/namespace.py
+++ b/wsgiservice_restplus/namespace.py
@@ -80,7 +80,7 @@ class Namespace(object):
             if doc is not None:
                 self._handle_api_doc(cls, doc)
 
-            if getattr(cls,'_path', None) is None:
+            if getattr(cls, '_path', None) is None:
                 cls._path = url
             else:
                 if cls._path != url:
@@ -278,6 +278,40 @@ class Namespace(object):
     def marshal_list_with(self, fields, **kwargs):
         """A shortcut decorator for :meth:`~Api.marshal_with` with ``as_list=True``"""
         return self.marshal_with(fields, True, **kwargs)
+
+
+    def marshal_entity_versions_with(self, produces, as_list=False, code=200, description=None, **kwargs):
+        """
+        TODO: Write docs
+        :param produces:
+        :param code:
+        :param description:
+        :param kwargs:
+        :return:
+        """
+
+        def wrapper(func):
+            content = []
+            for content_type, fields in produces.iteritems():
+                content.append({
+                    content_type: [fields] if as_list else fields,
+                })
+
+            doc = {
+                'responses': {
+                    code: (description, content),
+                },
+            }
+
+            func.__apidoc__ = merge(getattr(func, '__apidoc__', {}), doc)
+            return func
+
+        return wrapper
+
+
+    def marshal_entity_versions_list_with(self, produces, **kwargs):
+        """A shortcut decorator for :meth:`~Api.marshal_entity_versions_with` with ``as_list=True``"""
+        return self.marshal_entity_versions_with(produces, True, **kwargs)
 
 
     def errorhandler(self, exception):

--- a/wsgiservice_restplus/swagger.py
+++ b/wsgiservice_restplus/swagger.py
@@ -364,11 +364,41 @@ class Swagger(object):
         return params
 
     def responses_for(self, doc, method):
-
         responses = {}
 
         for d in doc, doc[method]:
-            if 'responses' in d:
+            # We are dealing with multiple responses for the same code (e.g. multiple entity representations)
+            if 'content' in d:
+                pass
+                # TODO: The response with openapi3 should have the following structure:
+                """
+                get:
+                  summary: FooBar
+                  responses:
+                    '200':
+                      description: FooBar
+                      content:
+                        application/json:  # Specify content type
+                          schema:
+                            $ref: '#/definitions/StreamMember'  # Model specific for the content type
+                        application/vnd.io.beekeeper.stream_membersv2+json:
+                          schema:
+                            $ref: '#/components/StreamMemberv2'
+                """
+
+                # for code, responses in iteritems(d['content']):
+                #     description, models_list = (responses, None) if isinstance(responses, string_types) else responses
+                #     description = description or DEFAULT_RESPONSE_DESCRIPTION
+                #     if code in responses:
+                #         responses[code].update(description=description)
+                #     else:
+                #         responses[code] = {'description': description}
+                #     # Make sure there is a list of representations where the list contains a dict
+                #     # E.g. - {'application/vnd.io.beekeeper.stream_membersv2+json': StreamMemberv2Model}
+                #     if isinstance(models_list, list):
+                #         # TODO: Have a list with all the available content types and their model
+            # There is only one response for a given code
+            elif 'responses' in d:
                 for code, response in iteritems(d['responses']):
                     description, model = (response, None) if isinstance(response, string_types) else response
                     description = description or DEFAULT_RESPONSE_DESCRIPTION


### PR DESCRIPTION
## BLOCKED:
The current provider we use for hosting the API docs (https://stoplight.io/) doesn't seem to support `openapi 3`. We have inquired about the support but until they don't support this PR will be blocked.

## Setting up
When changing the wsgiservice_restplus, one should use local version instead of the installed one. The following code can be included in the `Dockerfile.dev` file to copy over the local content (assuming it is in the beekeeper folder for simplicity) and install it with using `pip` from the local folder.
```
...
COPY ./wsgiservice-restplus /opt/beekeeper/wsgiservice-restplus
RUN pip install -e /opt/beekeeper/wsgiservice-restplus
```
## TODO:
- [ ] Update the `swagger 2` to `openapi 3`
- [ ] The structure of the generated `swagger.json` should be updated to meet the requirements for the `openapi 3`
- [ ] Allow `path responses` to include multiple content types. Each content different content type should hold reference to a model. 

The structure of the responses with `openapi 3` should be the following: 
```
                get:
                  summary: FooBar
                  responses:
                    '200':
                      description: FooBar
                      content:
                        application/json:  # Specify content type
                          schema:
                            $ref: '#/definitions/StreamMember'  # Model specific for the content type
                        application/vnd.io.beekeeper.stream_membersv2+json:
                          schema:
                            $ref: '#/components/StreamMemberv2'
```
