### PR TITLE
FUL-18924: encode spaces in json reference URIs

### DIFF
--- a/__about__.py
+++ b/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 
 __description__ = "wsgiservice module extension adding swagger support."
 

--- a/wsgiservice_restplus/fields.py
+++ b/wsgiservice_restplus/fields.py
@@ -10,6 +10,7 @@ from six import itervalues, text_type, string_types
 
 from wsgiservice_restplus.errors import RestError
 from wsgiservice_restplus.inputs import date_from_iso8601, datetime_from_iso8601, datetime_from_rfc822
+from wsgiservice_restplus.swagger import format_definition_reference
 from wsgiservice_restplus.utils import not_none
 from wsgiservice_restplus.converters import Boolean as BooleanConverter
 from wsgiservice_restplus.converters import String as StringConverter
@@ -206,7 +207,7 @@ class Nested(Raw):
 
     def schema(self):
         schema = super(Nested, self).schema()
-        ref = '#/definitions/{0}'.format(self.nested.name)
+        ref = format_definition_reference(self.nested.name)
 
         if self.as_list:
             schema['type'] = 'array'

--- a/wsgiservice_restplus/model.py
+++ b/wsgiservice_restplus/model.py
@@ -11,6 +11,7 @@ from six import iteritems, itervalues
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import ValidationError
 
+from wsgiservice_restplus.swagger import format_definition_reference
 from wsgiservice_restplus.utils import not_none
 
 
@@ -114,7 +115,7 @@ class Model(dict, MutableMapping):
 
         if self.__parents__:
             refs = [
-                {'$ref': '#/definitions/{0}'.format(parent.name)}
+                {'$ref': format_definition_reference(parent.name)}
                 for parent in self.__parents__
             ]
 

--- a/wsgiservice_restplus/swagger.py
+++ b/wsgiservice_restplus/swagger.py
@@ -5,6 +5,8 @@ import re
 
 from inspect import isclass, getdoc
 from collections import Hashable
+from urllib import quote
+
 from six import string_types, itervalues, iteritems, iterkeys
 
 from wsgiservice_restplus._compat import OrderedDict
@@ -37,11 +39,13 @@ DEFAULT_RESPONSE_DESCRIPTION = 'Success'
 DEFAULT_RESPONSE = {'description': DEFAULT_RESPONSE_DESCRIPTION}
 
 
+def format_definition_reference(definition_name):
+    return '#/definitions/{0}'.format(quote(definition_name))
 
 def ref(model):
     '''Return a reference to model in definitions'''
     name = model.name if isinstance(model, Model) else model
-    return {'$ref': '#/definitions/{0}'.format(name)}
+    return {'$ref': format_definition_reference(name)}
 
 
 def _v(value):
@@ -390,7 +394,7 @@ class Swagger(object):
                         error_responses = getattr(handler, '__apidoc__', {}).get('responses', {})
                         code = list(error_responses.keys())[0] if error_responses else None
                         if code and exception.__name__ == name:
-                            responses[code] = {'$ref': '#/responses/{0}'.format(name)}
+                            responses[code] = {'$ref': '#/responses/{0}'.format(quote(name))}
                             break
 
         if not responses:


### PR DESCRIPTION
Currently this lib does not encode special characters in JSON reference paths. It is against the specs ( https://tools.ietf.org/html/rfc3986#section-2.4 ) and causes ugly errors to be shown:
![image](https://user-images.githubusercontent.com/9937780/87021864-01779e00-c1d6-11ea-8b5e-b85004f41cb9.png)
This PR introduces following change: 
Before: `$ref: '#/definitions/Comment Put'`
After `$ref: '#/definitions/Comment%20Put'`